### PR TITLE
fix: enable callbacks on initial component load

### DIFF
--- a/dash_graph.py
+++ b/dash_graph.py
@@ -50,7 +50,6 @@ class DashGraph:
         self.server = Flask(__name__)
         self.app = dash.Dash(__name__,
                              title='Load analyzer',
-                             prevent_initial_callbacks=True,
                              external_stylesheets=external_stylesheets,
                              server=self.server)
 


### PR DESCRIPTION
This PR creates a fix for our issue of old data appearing on the initial page load. It enables callbacks to be called when their output component is first loaded (default behavior) which updates our dataframe and the graphs created from it.