### PR TITLE
fix ps command in ubuntu 24.04 

### DIFF
--- a/monitor.py
+++ b/monitor.py
@@ -26,7 +26,7 @@ ps_arg_tuples = [
 
 ps_args = ''
 for arg_tuple in ps_arg_tuples:
-    ps_args += ' -o "|%p" -o '
+    ps_args += ' -o "|%p " -o '
     ps_args += arg_tuple[0]
 
 COMMAND = f"ps  -e {ps_args}"


### PR DESCRIPTION
so the column name from query keeps the same

```
in ubuntu 22.04
root@37a04346fda0:/# ps -e  -o "|%p" -o pid -o "|%p" -o ppid -o "|%p" -o user:30 -o "|%p" -o comm -o "|%p" -o cputimes -o "|%p" -o rss -o "|%p" -o vsz -o "|%p" -o thcount -o "|%p" -o etimes -o "|%p" -o bsdstart -o "|%p" -o args
|  PID   PID|  PID  PPID|  PID USER                          |  PID COMMAND        |  PID     TIME|  PID   RSS|  PID    VSZ|  PID THCNT|  PID ELAPSED|  PID  START|  PID COMMAND
|    1     1|    1     0|    1 root                          |    1 bash           |    1        0|    1  3200|    1   4116|    1     1|    1     237|    1  22:31|    1 bash
|   11    11|   11     1|   11 root                          |   11 ps             |   11        0|   11  2432|   11   6408|   11     1|   11       0|   11  22:35|   11 ps -e -o |%p -o pid -o |%p -o ppid -o |%p -o user:30 -o |%p -o comm -o |%

in ubuntu 24.04

root@d135d5fbea26:/# ps -e  -o "|%p" -o pid -o "|%p" -o ppid -o "|%p" -o user:30 -o "|%p" -o comm -o "|%p" -o cputimes -o "|%p" -o rss -o "|%p" -o vsz -o "|%p" -o thcount -o "|%p" -o etimes -o "|%p" -o bsdstart -o "|%p" -o args
|  PID  PID|  PID PPID|  PIDUSER                          |  PIDCOMMAND        |  PID    TIME|  PID  RSS|  PID   VSZ|  PIDTHCNT|  PIDELAPSED|  PID START|  PIDCOMMAND
|    1    1|    1    0|    1root                          |    1bash           |    1       0|    1 3584|    1  4296|    1    1|    1     10|    1 22:35|    1bash
|    9    9|    9    1|    9root                          |    9ps             |    9       0|    9 3456|    9  7596|    9    1|    9      0|    9 22:35|    9ps -e -o |%p -o pid -o |%p -o ppid -o |%p -o user:30 -o |%p -o comm -o |%p -o cputim
```